### PR TITLE
enforced attention class to be 'eager' in order to enable usage of torch>2.1

### DIFF
--- a/lxt/models/llama.py
+++ b/lxt/models/llama.py
@@ -421,7 +421,7 @@ class LlamaDecoderLayer(nn.Module):
         super().__init__()
         self.hidden_size = config.hidden_size
 
-        self.self_attn = LLAMA_ATTENTION_CLASSES[config._attn_implementation](config=config, layer_idx=layer_idx)
+        self.self_attn = LLAMA_ATTENTION_CLASSES["eager"](config=config, layer_idx=layer_idx)
 
         self.mlp = LlamaMLP(config)
         self.input_layernorm = RMSNormIdentity(config.hidden_size, eps=config.rms_norm_eps)

--- a/lxt/models/mixtral.py
+++ b/lxt/models/mixtral.py
@@ -509,7 +509,7 @@ class MixtralDecoderLayer(nn.Module):
         super().__init__()
         self.hidden_size = config.hidden_size
 
-        self.self_attn = MISTRAL_ATTENTION_CLASSES[config._attn_implementation](config, layer_idx)
+        self.self_attn = MISTRAL_ATTENTION_CLASSES["eager"](config, layer_idx)
 
         self.block_sparse_moe = MixtralSparseMoeBlock(config)
         self.input_layernorm = RMSNormIdentity(config.hidden_size, eps=config.rms_norm_eps)

--- a/lxt/models/phi3.py
+++ b/lxt/models/phi3.py
@@ -850,7 +850,7 @@ class Phi3DecoderLayer(nn.Module):
         super().__init__()
 
         self.config = config
-        self.self_attn = PHI3_ATTENTION_CLASSES[config._attn_implementation](config, layer_idx=layer_idx)
+        self.self_attn = PHI3_ATTENTION_CLASSES["eager"](config, layer_idx=layer_idx)
 
         self.mlp = Phi3MLP(config)
         self.input_layernorm = RMSNormIdentity(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
Before torch version > 2.1 would not work for the llama model. Possibly mixtral and hi3 could have been affected with newer pytorch version.  By enforcing "eager"  the KeyError is prevented. 